### PR TITLE
Fix error in sample configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ An example configuration:
 	    amazon_es {
 	        hosts => ["foo.us-east-1.es.amazonaws.com"]
 	        region => "us-east-1"
-			access_key => 'ACCESS_KEY' (Will be made optional in next release to support instance profiles)
-			secret_key => 'SECRET_KEY' 
+			aws_access_key_id => 'ACCESS_KEY' (Will be made optional in next release to support instance profiles)
+			aws_secret_access_key => 'SECRET_KEY' 
 			index => "production-logs-%{+YYYY.MM.dd}"
 		}
 	}


### PR DESCRIPTION
The keys did not match what the plugin expected.

I tried with the provided example, but got errors:

```
$ bin/logstash agent -f /etc/logstash/logstash.conf --configtest
Unknown setting 'access_key' for amazon_es {:level=>:error}
Unknown setting 'secret_key' for amazon_es {:level=>:error}
Error: Something is wrong with your configuration.
```

This change passes the config test.